### PR TITLE
Add advanced filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # cielo_azure_billing
-Service to provide azure billing analysis information. 
+Service to provide azure billing analysis information.
+
+## API Filtering
+
+Cost entry endpoints accept the following query parameters for filtering:
+
+- `resourceGroupName`
+- `subscriptionName`
+- `meterCategory`
+- `meterSubCategory`
+- `serviceFamily`
+- `resourceLocation`
+- `chargeType`
+- `pricingModel`
+- `publisherName`
+- `costCenter`
+- `tags`

--- a/billing/admin.py
+++ b/billing/admin.py
@@ -58,6 +58,18 @@ class CostEntryAdmin(admin.ModelAdmin):
         'pricing_model',
         'publisher_name',
         'cost_center',
+        'tags',
     )
-    search_fields = ('subscription__name', 'resource__name')
+    search_fields = (
+        'subscription__name',
+        'resource__name',
+        'resource__resource_group',
+        'resource__location',
+        'meter__category',
+        'meter__subcategory',
+        'meter__service_family',
+        'publisher_name',
+        'cost_center',
+        'tags',
+    )
     readonly_fields = ('snapshot',)

--- a/billing/filters.py
+++ b/billing/filters.py
@@ -1,0 +1,25 @@
+from django_filters import rest_framework as filters
+from .models import CostEntry
+
+
+class CostEntryFilter(filters.FilterSet):
+    resourceGroupName = filters.CharFilter(field_name='resource__resource_group', lookup_expr='iexact')
+    subscriptionName = filters.CharFilter(field_name='subscription__name', lookup_expr='iexact')
+    meterCategory = filters.CharFilter(field_name='meter__category', lookup_expr='iexact')
+    meterSubCategory = filters.CharFilter(field_name='meter__subcategory', lookup_expr='iexact')
+    serviceFamily = filters.CharFilter(field_name='meter__service_family', lookup_expr='iexact')
+    resourceLocation = filters.CharFilter(field_name='resource__location', lookup_expr='iexact')
+    chargeType = filters.CharFilter(field_name='charge_type', lookup_expr='iexact')
+    pricingModel = filters.CharFilter(field_name='pricing_model', lookup_expr='iexact')
+    publisherName = filters.CharFilter(field_name='publisher_name', lookup_expr='iexact')
+    costCenter = filters.CharFilter(field_name='cost_center', lookup_expr='iexact')
+    tags = filters.CharFilter(method='filter_tags')
+
+    class Meta:
+        model = CostEntry
+        fields = []
+
+    def filter_tags(self, queryset, name, value):
+        if value:
+            return queryset.filter(tags__contains=value)
+        return queryset

--- a/cielo_azure_billing/settings.py
+++ b/cielo_azure_billing/settings.py
@@ -15,6 +15,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'rest_framework.authtoken',
     'drf_spectacular',
+    'django_filters',
     'billing',
 ]
 
@@ -72,6 +73,9 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',
+    ),
+    'DEFAULT_FILTER_BACKENDS': (
+        'django_filters.rest_framework.DjangoFilterBackend',
     ),
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ django = "^5.0"
 djangorestframework = "^3.15"
 pydantic = "^2.0"
 drf-spectacular = "^0.28.0"
+django-filter = "^24.2"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Summary
- support DRF filtering via django-filter
- document available filters in README and OpenAPI
- extend CostEntry admin search and filtering
- enable django-filter in Django settings
- add django-filter dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added advanced filtering options to the billing data API, allowing users to filter cost entries by resource group, subscription, meter category, service family, location, charge type, pricing model, publisher, cost center, and tags.
  - Enhanced the Django admin interface with improved search and filter capabilities for cost entries, including tag-based filtering.

- **Documentation**
  - Updated the README to document new API filtering capabilities and available query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->