### PR TITLE
Add auto discovery for Azure billing exports

### DIFF
--- a/billing/admin.py
+++ b/billing/admin.py
@@ -13,86 +13,98 @@ from .models import (
 @admin.register(ImportSnapshot)
 class ImportSnapshotAdmin(admin.ModelAdmin):
     list_display = (
-        'file_name',
-        'run_id',
-        'report_date',
-        'created_at',
-        'source',
+        "file_name",
+        "run_id",
+        "report_date",
+        "created_at",
+        "source",
     )
-    search_fields = ('file_name',)
+    search_fields = ("file_name",)
 
 
 @admin.register(BillingBlobSource)
 class BillingBlobSourceAdmin(admin.ModelAdmin):
-    list_display = ('name', 'guid', 'is_active', 'status')
-    list_filter = ('is_active',)
-    search_fields = ('name', 'guid')
-    readonly_fields = ('last_imported_at', 'last_attempted_at', 'status', 'is_active')
-    fields = ('name', 'path_template', 'guid')
+    list_display = ("name", "base_folder", "is_active", "status")
+    list_filter = ("is_active",)
+    search_fields = ("name", "base_folder")
+    readonly_fields = (
+        "last_imported_at",
+        "last_attempted_at",
+        "status",
+        "is_active",
+    )
+    fields = ("name", "base_folder")
 
 
 @admin.register(Customer)
 class CustomerAdmin(admin.ModelAdmin):
-    search_fields = ('tenant_id', 'name')
+    search_fields = ("tenant_id", "name")
 
 
 @admin.register(Subscription)
 class SubscriptionAdmin(admin.ModelAdmin):
-    list_display = ('subscription_id', 'name', 'customer')
-    list_filter = ('customer',)
-    search_fields = ('subscription_id', 'name')
+    list_display = ("subscription_id", "name", "customer")
+    list_filter = ("customer",)
+    search_fields = ("subscription_id", "name")
 
 
 @admin.register(Resource)
 class ResourceAdmin(admin.ModelAdmin):
-    list_display = ('resource_id', 'name', 'resource_group', 'location')
-    search_fields = ('resource_id', 'name', 'resource_group', 'location')
+    list_display = ("resource_id", "name", "resource_group", "location")
+    search_fields = ("resource_id", "name", "resource_group", "location")
 
 
 @admin.register(Meter)
 class MeterAdmin(admin.ModelAdmin):
-    list_display = ('meter_id', 'name', 'category', 'subcategory', 'service_family', 'unit')
-    search_fields = ('meter_id', 'name', 'category', 'service_family')
+    list_display = (
+        "meter_id",
+        "name",
+        "category",
+        "subcategory",
+        "service_family",
+        "unit",
+    )
+    search_fields = ("meter_id", "name", "category", "service_family")
 
 
 @admin.register(CostEntry)
 class CostEntryAdmin(admin.ModelAdmin):
     list_display = (
-        'date',
-        'subscription',
-        'resource',
-        'meter',
-        'charge_type',
-        'pricing_model',
-        'publisher_name',
-        'cost_center',
-        'cost_in_usd',
+        "date",
+        "subscription",
+        "resource",
+        "meter",
+        "charge_type",
+        "pricing_model",
+        "publisher_name",
+        "cost_center",
+        "cost_in_usd",
     )
     list_filter = (
-        'snapshot',
-        'date',
-        'subscription',
-        'resource__resource_group',
-        'resource__location',
-        'meter__category',
-        'meter__subcategory',
-        'meter__service_family',
-        'charge_type',
-        'pricing_model',
-        'publisher_name',
-        'cost_center',
-        'tags',
+        "snapshot",
+        "date",
+        "subscription",
+        "resource__resource_group",
+        "resource__location",
+        "meter__category",
+        "meter__subcategory",
+        "meter__service_family",
+        "charge_type",
+        "pricing_model",
+        "publisher_name",
+        "cost_center",
+        "tags",
     )
     search_fields = (
-        'subscription__name',
-        'resource__name',
-        'resource__resource_group',
-        'resource__location',
-        'meter__category',
-        'meter__subcategory',
-        'meter__service_family',
-        'publisher_name',
-        'cost_center',
-        'tags',
+        "subscription__name",
+        "resource__name",
+        "resource__resource_group",
+        "resource__location",
+        "meter__category",
+        "meter__subcategory",
+        "meter__service_family",
+        "publisher_name",
+        "cost_center",
+        "tags",
     )
-    readonly_fields = ('snapshot',)
+    readonly_fields = ("snapshot",)

--- a/billing/management/commands/fetch_and_import_from_blob.py
+++ b/billing/management/commands/fetch_and_import_from_blob.py
@@ -2,16 +2,18 @@ import datetime
 import json
 import logging
 from pathlib import Path
+from urllib.parse import urlparse
 from django.core.management.base import BaseCommand
 from billing.models import BillingBlobSource, ImportSnapshot
 from billing.services import CostCsvImporter
 
 try:
     from azure.identity import DefaultAzureCredential
-    from azure.storage.blob import BlobClient
+    from azure.storage.blob import BlobClient, ContainerClient
 except Exception:  # pragma: no cover - libs optional for offline env
     DefaultAzureCredential = None
     BlobClient = None
+    ContainerClient = None
 
 logger = logging.getLogger(__name__)
 
@@ -49,52 +51,96 @@ class Command(BaseCommand):
         end = today
         return f"{start:%Y%m%d}-{end:%Y%m%d}"
 
+    def _parse_base_folder(self, base):
+        parsed = urlparse(base)
+        path = parsed.path.lstrip("/")
+        parts = path.split("/", 1)
+        container = parts[0]
+        prefix = ""
+        if len(parts) > 1:
+            prefix = parts[1].rstrip("/") + "/"
+        container_url = f"{parsed.scheme}://{parsed.netloc}/{container}"
+        return container_url, prefix
+
     def _process_source(self, source, period, dry_run, overwrite):
         source.last_attempted_at = datetime.datetime.utcnow()
         try:
             if DefaultAzureCredential is None:
                 raise RuntimeError("Azure SDK not installed")
-            manifest_url = source.path_template.format(billing_period=period, guid=source.guid) + "/manifest.json"
+
             cred = DefaultAzureCredential()
-            blob_client = BlobClient.from_blob_url(manifest_url, credential=cred)
-            manifest_data = json.loads(blob_client.download_blob().readall())
-            run_id = manifest_data.get("runInfo", {}).get("runId")
-            report_date_raw = manifest_data.get("runInfo", {}).get("endDate")
-            report_date = None
-            if report_date_raw:
-                report_date = datetime.date.fromisoformat(report_date_raw.split("T")[0])
-            if ImportSnapshot.objects.filter(run_id=run_id).exists() and not overwrite:
-                source.status = "skipped"
+            container_url, prefix = self._parse_base_folder(source.base_folder)
+            client = ContainerClient.from_container_url(container_url, credential=cred)
+
+            listing_prefix = prefix
+            if period:
+                listing_prefix = f"{prefix}{period}/"
+
+            blobs = client.list_blobs(name_starts_with=listing_prefix)
+            manifests = [b for b in blobs if b.name.endswith("manifest.json")]
+            if not manifests:
+                source.status = "no-manifests"
                 source.save(update_fields=["last_attempted_at", "status"])
-                logger.info("Skip existing run %s for %s", run_id, source.name)
+                logger.info("No manifests found for %s", source.name)
                 return
-            blob_name = manifest_data.get("blobs", [{}])[0].get("blobName")
-            if not blob_name:
-                raise RuntimeError("No blobName in manifest")
-            csv_url = source.path_template.format(billing_period=period, guid=source.guid) + f"/{Path(blob_name).name}"
-            blob_client = BlobClient.from_blob_url(csv_url, credential=cred)
-            tmp_dir = Path(self.mktemp())
-            gz_path = tmp_dir / Path(blob_name).name
-            manifest_path = tmp_dir / "manifest.json"
-            with open(gz_path, "wb") as fh:
-                fh.write(blob_client.download_blob().readall())
-            with open(manifest_path, "w", encoding="utf-8") as fh:
-                json.dump(manifest_data, fh)
-            import gzip
-            csv_path = tmp_dir / (gz_path.stem)
-            with gzip.open(gz_path, "rb") as f_in, open(csv_path, "wb") as f_out:
-                f_out.write(f_in.read())
-            if dry_run:
-                source.status = "dry-run"
-                logger.info("Dry run completed for %s. Files stored at %s", source.name, tmp_dir)
-            else:
-                importer = CostCsvImporter(str(csv_path), run_id=run_id, report_date=report_date, source=source)
-                importer.import_file()
-                source.last_imported_at = datetime.datetime.utcnow()
-                source.status = "imported"
-            source.save(update_fields=["last_attempted_at", "last_imported_at", "status"])
+
+            for blob in manifests:
+                manifest_url = f"{container_url}/{blob.name}"
+                bclient = BlobClient.from_blob_url(manifest_url, credential=cred)
+                manifest_data = json.loads(bclient.download_blob().readall())
+                run_id = manifest_data.get("runInfo", {}).get("runId")
+                report_date_raw = manifest_data.get("runInfo", {}).get("endDate")
+                report_date = None
+                if report_date_raw:
+                    report_date = datetime.date.fromisoformat(
+                        report_date_raw.split("T")[0]
+                    )
+                if (
+                    ImportSnapshot.objects.filter(run_id=run_id).exists()
+                    and not overwrite
+                ):
+                    logger.info("Skip existing run %s for %s", run_id, source.name)
+                    continue
+
+                blob_name = manifest_data.get("blobs", [{}])[0].get("blobName")
+                if not blob_name:
+                    raise RuntimeError("No blobName in manifest")
+                csv_url = f"{container_url}/{blob_name}"
+                bclient = BlobClient.from_blob_url(csv_url, credential=cred)
+
+                tmp_dir = Path(self.mktemp())
+                gz_path = tmp_dir / Path(blob_name).name
+                manifest_path = tmp_dir / "manifest.json"
+                with open(gz_path, "wb") as fh:
+                    fh.write(bclient.download_blob().readall())
+                with open(manifest_path, "w", encoding="utf-8") as fh:
+                    json.dump(manifest_data, fh)
+                import gzip
+
+                csv_path = tmp_dir / (gz_path.stem)
+                with gzip.open(gz_path, "rb") as f_in, open(csv_path, "wb") as f_out:
+                    f_out.write(f_in.read())
+                if dry_run:
+                    source.status = "dry-run"
+                    logger.info(
+                        "Dry run completed for %s. Files stored at %s",
+                        source.name,
+                        tmp_dir,
+                    )
+                else:
+                    importer = CostCsvImporter(
+                        str(csv_path),
+                        run_id=run_id,
+                        report_date=report_date,
+                        source=source,
+                    )
+                    importer.import_file()
+                    source.last_imported_at = datetime.datetime.utcnow()
+                    source.status = "imported"
+                source.save(
+                    update_fields=["last_attempted_at", "last_imported_at", "status"]
+                )
         except Exception as exc:
             source.status = f"error: {exc}"
             source.save(update_fields=["last_attempted_at", "status"])
             logger.error("Failed to import from %s: %s", source.name, exc)
-

--- a/billing/management/commands/inspect_blob_source.py
+++ b/billing/management/commands/inspect_blob_source.py
@@ -1,0 +1,82 @@
+import json
+import logging
+from urllib.parse import urlparse
+
+from django.core.management.base import BaseCommand
+
+from billing.models import BillingBlobSource, ImportSnapshot
+
+try:
+    from azure.identity import DefaultAzureCredential
+    from azure.storage.blob import BlobClient, ContainerClient
+except Exception:  # pragma: no cover - libs optional for offline env
+    DefaultAzureCredential = None
+    BlobClient = None
+    ContainerClient = None
+
+logger = logging.getLogger(__name__)
+
+
+def parse_base_folder(base):
+    parsed = urlparse(base)
+    path = parsed.path.lstrip("/")
+    parts = path.split("/", 1)
+    container = parts[0]
+    prefix = ""
+    if len(parts) > 1:
+        prefix = parts[1].rstrip("/") + "/"
+    container_url = f"{parsed.scheme}://{parsed.netloc}/{container}"
+    return container_url, prefix
+
+
+class Command(BaseCommand):
+    help = "List available export runs for a BillingBlobSource"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--source-name", required=True, help="BillingBlobSource name"
+        )
+        parser.add_argument(
+            "--billing-period", help="Billing period in YYYYMMDD-YYYYMMDD format"
+        )
+
+    def handle(self, *args, **options):
+        name = options["source_name"]
+        period = options.get("billing_period")
+        source = BillingBlobSource.objects.filter(name=name).first()
+        if not source:
+            self.stdout.write(self.style.ERROR(f"Source {name} not found"))
+            return
+
+        if DefaultAzureCredential is None:
+            self.stderr.write("Azure SDK not installed")
+            return
+
+        try:
+            cred = DefaultAzureCredential()
+            container_url, prefix = parse_base_folder(source.base_folder)
+            client = ContainerClient.from_container_url(container_url, credential=cred)
+
+            listing_prefix = prefix
+            if period:
+                listing_prefix = f"{prefix}{period}/"
+
+            blobs = client.list_blobs(name_starts_with=listing_prefix)
+            manifests = [b for b in blobs if b.name.endswith("manifest.json")]
+            if not manifests:
+                self.stdout.write("No runs found")
+                return
+
+            for blob in manifests:
+                manifest_url = f"{container_url}/{blob.name}"
+                bclient = BlobClient.from_blob_url(manifest_url, credential=cred)
+                manifest_data = json.loads(bclient.download_blob().readall())
+                run_id = manifest_data.get("runInfo", {}).get("runId")
+                end_date = manifest_data.get("runInfo", {}).get("endDate")
+                imported = ImportSnapshot.objects.filter(run_id=run_id).exists()
+                self.stdout.write(
+                    f"run_id={run_id} end_date={end_date} size={blob.size} imported={imported}"
+                )
+        except Exception as exc:
+            logger.error("Inspection failed: %s", exc)
+            self.stderr.write(str(exc))

--- a/billing/migrations/0002_blob_source_base_folder.py
+++ b/billing/migrations/0002_blob_source_base_folder.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("billing", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="billingblobsource",
+            name="base_folder",
+            field=models.CharField(
+                default="",
+                max_length=255,
+                help_text="Base export folder e.g. costreports/prod/prod-actual-cost/",
+            ),
+            preserve_default=False,
+        ),
+        migrations.RemoveField(
+            model_name="billingblobsource",
+            name="path_template",
+        ),
+        migrations.RemoveField(
+            model_name="billingblobsource",
+            name="guid",
+        ),
+    ]

--- a/billing/models.py
+++ b/billing/models.py
@@ -5,10 +5,10 @@ class BillingBlobSource(models.Model):
     """Configuration for locating cost export blobs."""
 
     name = models.CharField(max_length=100)
-    path_template = models.TextField(
-        help_text="Use placeholders {billing_period} and {guid} in the template"
+    base_folder = models.CharField(
+        max_length=255,
+        help_text="Base export folder e.g. costreports/prod/prod-actual-cost/",
     )
-    guid = models.CharField(max_length=64)
     is_active = models.BooleanField(default=True)
     last_imported_at = models.DateTimeField(null=True, blank=True)
     last_attempted_at = models.DateTimeField(null=True, blank=True)
@@ -101,11 +101,15 @@ class CostEntry(models.Model):
     resource = models.ForeignKey(Resource, on_delete=models.CASCADE)
     meter = models.ForeignKey(Meter, on_delete=models.CASCADE)
     cost_in_usd = models.DecimalField(max_digits=12, decimal_places=4)
-    cost_in_billing_currency = models.DecimalField(max_digits=12, decimal_places=4, null=True, blank=True)
+    cost_in_billing_currency = models.DecimalField(
+        max_digits=12, decimal_places=4, null=True, blank=True
+    )
     billing_currency = models.CharField(max_length=10, null=True, blank=True)
     quantity = models.DecimalField(max_digits=12, decimal_places=4)
     unit_price = models.DecimalField(max_digits=12, decimal_places=6)
-    payg_price = models.DecimalField(max_digits=12, decimal_places=6, null=True, blank=True)
+    payg_price = models.DecimalField(
+        max_digits=12, decimal_places=6, null=True, blank=True
+    )
     pricing_model = models.CharField(max_length=64, null=True, blank=True)
     charge_type = models.CharField(max_length=64, null=True, blank=True)
     publisher_name = models.CharField(max_length=255, null=True, blank=True)
@@ -113,15 +117,15 @@ class CostEntry(models.Model):
     tags = models.JSONField(null=True, blank=True)
 
     def __str__(self):
-        return f'{self.date} - {self.subscription}'
+        return f"{self.date} - {self.subscription}"
 
     class Meta:
         unique_together = (
-            'snapshot',
-            'date',
-            'subscription',
-            'resource',
-            'meter',
-            'quantity',
-            'unit_price',
+            "snapshot",
+            "date",
+            "subscription",
+            "resource",
+            "meter",
+            "quantity",
+            "unit_price",
         )

--- a/docs/BLOB_IMPORT.md
+++ b/docs/BLOB_IMPORT.md
@@ -2,15 +2,14 @@
 
 This project supports automated fetching of Azure cost export files directly from
 Azure Blob Storage. Sources are defined with the `BillingBlobSource` model which
-stores the path template and metadata about each import attempt.
+stores the base folder to scan and metadata about each import attempt.
 
 ## Models
 
 ### BillingBlobSource
 - `name` – friendly identifier used by CLI options
-    - `path_template` – format string with `{billing_period}` and `{guid}`
-    - `guid` – export GUID from Azure
-    - `is_active` – enable/disable the source
+    - `base_folder` – root folder containing export runs
+- `is_active` – enable/disable the source
 - timestamps for last attempt and import plus a `status` field
 
 ### ImportSnapshot
@@ -24,9 +23,14 @@ latest snapshot per subscription or for a specific day.
 ## Management Command
 
 `python manage.py fetch_and_import_from_blob` reads all active
-`BillingBlobSource` entries, downloads the `manifest.json` and related csv.gz
-file for a billing period and imports the cost entries. Options allow limiting to
-specific source names, overwriting existing snapshots and performing dry runs.
+`BillingBlobSource` entries, discovers available export runs under the configured
+`base_folder`, downloads the `manifest.json` and related csv.gz file and imports
+the cost entries. Options allow limiting to specific source names, overwriting
+existing snapshots and performing dry runs.
+
+`python manage.py inspect_blob_source` lists discovered export runs without
+downloading them. It accepts the same `--source-name` and optional
+`--billing-period` arguments to filter results.
 
 The command relies on the Azure SDK (`azure-identity` and `azure-storage-blob`)
 using `DefaultAzureCredential` for authentication.


### PR DESCRIPTION
## Summary
- add `base_folder` field for BillingBlobSource and remove template/guid
- dynamically discover available export runs in `fetch_and_import_from_blob`
- provide new `inspect_blob_source` command for listing runs
- document updated model and commands
- include migration for schema changes

## Testing
- `ruff check billing --fix`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a management command to inspect and list available export runs from Azure Blob sources, with filtering options.
- **Refactor**
  - Updated Azure cost report import to support processing multiple manifests per source, improving flexibility and reliability.
  - Replaced the path template configuration with a simpler base folder path for Azure Blob sources.
- **Documentation**
  - Updated documentation to reflect changes in configuration fields and new management command usage.
- **Chores**
  - Removed obsolete fields and updated model structure for billing blob sources.
- **Style**
  - Improved code formatting and consistency in string usage and field declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->