### PR TITLE
Add snapshot status tracking

### DIFF
--- a/billing/migrations/0004_costreportsnapshot_status.py
+++ b/billing/migrations/0004_costreportsnapshot_status.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("billing", "0003_rename_importsnapshot_to_costreportsnapshot"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="costreportsnapshot",
+            name="status",
+            field=models.CharField(
+                max_length=20,
+                choices=[
+                    ("in_progress", "in_progress"),
+                    ("complete", "complete"),
+                    ("failed", "failed"),
+                ],
+                default="in_progress",
+                db_index=True,
+            ),
+        ),
+    ]

--- a/billing/utils.py
+++ b/billing/utils.py
@@ -3,7 +3,10 @@ from .models import CostReportSnapshot
 def get_latest_snapshot_for_date(billing_date):
     """Return the newest snapshot that contains cost entries for billing_date."""
     return (
-        CostReportSnapshot.objects.filter(costentry__date=billing_date)
+        CostReportSnapshot.objects.filter(
+            costentry__date=billing_date,
+            status=CostReportSnapshot.Status.COMPLETE,
+        )
         .order_by('-created_at')
         .first()
     )


### PR DESCRIPTION
## Summary
- add `status` field to `CostReportSnapshot` with choices
- track status in `CostCsvImporter`
- filter queries for completed snapshots
- add migration
- update tests

## Testing
- `poetry run python manage.py test -v 2` *(fails: ModuleNotFoundError: No module named 'django')*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a status field to cost report snapshots, allowing them to be tracked as "in progress", "complete", or "failed".

- **Bug Fixes**
  - Improved filtering so that only completed cost report snapshots are considered in relevant queries and reports.

- **Tests**
  - Enhanced tests to verify correct status assignment and filtering of snapshots based on their status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->