### PR TITLE
Add cost summary endpoints with caching

### DIFF
--- a/billing/filters.py
+++ b/billing/filters.py
@@ -23,3 +23,34 @@ class CostEntryFilter(filters.FilterSet):
         if value:
             return queryset.filter(tags__contains=value)
         return queryset
+
+
+class CostSummaryFilter(filters.FilterSet):
+    subscription_id = filters.CharFilter(field_name='subscription__subscription_id', lookup_expr='iexact')
+    resource_group = filters.CharFilter(field_name='resource__resource_group', lookup_expr='iexact')
+    location = filters.CharFilter(field_name='resource__location', lookup_expr='iexact')
+    meter_category = filters.CharFilter(field_name='meter__category', lookup_expr='iexact')
+    meter_subcategory = filters.CharFilter(field_name='meter__subcategory', lookup_expr='iexact')
+    pricing_model = filters.CharFilter(field_name='pricing_model', lookup_expr='iexact')
+    publisher_name = filters.CharFilter(field_name='publisher_name', lookup_expr='iexact')
+    resource_name = filters.CharFilter(field_name='resource__resource_name', lookup_expr='iexact')
+    min_cost = filters.NumberFilter(field_name='cost_in_usd', lookup_expr='gte')
+    max_cost = filters.NumberFilter(field_name='cost_in_usd', lookup_expr='lte')
+    source_id = filters.NumberFilter(field_name='snapshot__source_id')
+    tag_key = filters.CharFilter(method='filter_tag_key')
+    tag_value = filters.CharFilter(method='filter_tag_value')
+
+    class Meta:
+        model = CostEntry
+        fields = []
+
+    def filter_tag_key(self, queryset, name, value):
+        if value:
+            return queryset.filter(tags__has_key=value)
+        return queryset
+
+    def filter_tag_value(self, queryset, name, value):
+        key = self.data.get('tag_key')
+        if key and value:
+            return queryset.filter(tags__contains={key: value})
+        return queryset

--- a/billing/tests/test_summary_api.py
+++ b/billing/tests/test_summary_api.py
@@ -1,0 +1,38 @@
+import datetime
+from django.test import TestCase
+from django.urls import reverse
+from billing.models import (
+    BillingBlobSource,
+    CostReportSnapshot,
+    Customer,
+    Subscription,
+    Resource,
+    Meter,
+    CostEntry,
+)
+
+
+class SubscriptionSummaryAPITests(TestCase):
+    def setUp(self):
+        self.source1 = BillingBlobSource.objects.create(name='s1', base_folder='f1')
+        self.source2 = BillingBlobSource.objects.create(name='s2', base_folder='f2')
+        customer = Customer.objects.create(tenant_id='t1')
+        self.sub1 = Subscription.objects.create(subscription_id='sub1', name='Sub1', customer=customer)
+        self.sub2 = Subscription.objects.create(subscription_id='sub2', name='Sub2', customer=customer)
+        self.res = Resource.objects.create(resource_id='r1')
+        self.meter = Meter.objects.create(meter_id='m1', name='m1', category='Virtual Machines', unit='h')
+        date = datetime.date(2024, 1, 1)
+        snap1 = CostReportSnapshot.objects.create(run_id='r1', report_date=date, file_name='f1', source=self.source1, status=CostReportSnapshot.Status.COMPLETE)
+        snap2 = CostReportSnapshot.objects.create(run_id='r2', report_date=date, file_name='f2', source=self.source2, status=CostReportSnapshot.Status.COMPLETE)
+        CostEntry.objects.create(snapshot=snap1, date=date, subscription=self.sub1, resource=self.res, meter=self.meter, cost_in_usd=1, quantity=1, unit_price=1)
+        CostEntry.objects.create(snapshot=snap2, date=date, subscription=self.sub2, resource=self.res, meter=self.meter, cost_in_usd=2, quantity=1, unit_price=1)
+
+    def test_subscription_summary(self):
+        url = '/api/costs/subscription-summary/?date=2024-01-01'
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()['data']
+        sub_ids = {item['subscription_id'] for item in data}
+        self.assertEqual(sub_ids, {'sub1', 'sub2'})
+
+

--- a/billing/urls.py
+++ b/billing/urls.py
@@ -7,6 +7,11 @@ from .views import (
     ResourceViewSet,
     MeterViewSet,
     CostEntryViewSet,
+    SubscriptionSummaryView,
+    VirtualMachineSummaryView,
+    ResourceGroupSummaryView,
+    MeterCategorySummaryView,
+    RegionSummaryView,
 )
 
 router = DefaultRouter()
@@ -19,4 +24,9 @@ router.register('cost-entries', CostEntryViewSet)
 
 urlpatterns = [
     path('', include(router.urls)),
+    path('costs/subscription-summary/', SubscriptionSummaryView.as_view()),
+    path('costs/virtual-machines-summary/', VirtualMachineSummaryView.as_view()),
+    path('costs/resource-group-summary/', ResourceGroupSummaryView.as_view()),
+    path('costs/meter-category-summary/', MeterCategorySummaryView.as_view()),
+    path('costs/region-summary/', RegionSummaryView.as_view()),
 ]

--- a/billing/utils.py
+++ b/billing/utils.py
@@ -1,4 +1,6 @@
 from .models import CostReportSnapshot
+from .models import BillingBlobSource
+
 
 def get_latest_snapshot_for_date(billing_date):
     """Return the newest snapshot that contains cost entries for billing_date."""
@@ -6,8 +8,31 @@ def get_latest_snapshot_for_date(billing_date):
         CostReportSnapshot.objects.filter(
             costentry__date=billing_date,
             status=CostReportSnapshot.Status.COMPLETE,
-        )
+    )
         .order_by('-created_at')
         .first()
     )
+
+
+def get_latest_snapshots(date=None):
+    """Return latest completed snapshot per active source matching date if provided.
+
+    Returns tuple of (snapshots, missing_sources).
+    """
+    snapshots = []
+    missing = []
+    for source in BillingBlobSource.objects.filter(is_active=True):
+        qs = CostReportSnapshot.objects.filter(
+            source=source,
+            status=CostReportSnapshot.Status.COMPLETE,
+        )
+        if date:
+            qs = qs.filter(costentry__date=date)
+        snap = qs.order_by('-created_at').first()
+        if snap:
+            snapshots.append(snap)
+        else:
+            reason = 'no snapshot for date' if date else 'no snapshot'
+            missing.append({'name': source.name, 'reason': reason})
+    return snapshots, missing
 

--- a/billing/views.py
+++ b/billing/views.py
@@ -1,10 +1,11 @@
 import datetime
 from rest_framework import viewsets
+from rest_framework.views import APIView
 from rest_framework.decorators import action
 from rest_framework.response import Response
-from django.db.models import Sum
+from django.db.models import Sum, F
 from django_filters.rest_framework import DjangoFilterBackend
-from .models import CostReportSnapshot, Customer, Subscription, Resource, Meter, CostEntry
+from .models import BillingBlobSource, CostReportSnapshot, Customer, Subscription, Resource, Meter, CostEntry
 from .serializers import (
     CostReportSnapshotSerializer,
     CustomerSerializer,
@@ -14,8 +15,9 @@ from .serializers import (
     CostEntrySerializer,
 )
 from .permissions import PublicEndpointPermission
-from .filters import CostEntryFilter
-from .utils import get_latest_snapshot_for_date
+from .filters import CostEntryFilter, CostSummaryFilter
+from .utils import get_latest_snapshot_for_date, get_latest_snapshots
+from caching import get_cache_backend
 from drf_spectacular.utils import extend_schema, OpenApiParameter
 
 
@@ -116,3 +118,95 @@ class CostEntryViewSet(viewsets.ModelViewSet):
             .order_by()
         )
         return Response(list(data))
+
+
+class BaseSummaryView(APIView):
+    permission_classes = [PublicEndpointPermission]
+    filterset_class = CostSummaryFilter
+    group_by = None  # tuple of (queryset field expressions, response keys)
+
+    def get_cache_key(self, request, date):
+        params = sorted(request.GET.items())
+        key = f"{request.path}|{date}|{params}"
+        return key
+
+    def get(self, request):
+        cache = get_cache_backend()
+        date_str = request.GET.get('date')
+        date = None
+        if date_str:
+            try:
+                date = datetime.date.fromisoformat(date_str)
+            except ValueError:
+                return Response({'detail': 'invalid date'}, status=400)
+
+        cache_key = self.get_cache_key(request, date_str)
+        cached = cache.get(cache_key)
+        if cached:
+            return Response(cached)
+
+        snapshots, missing = get_latest_snapshots(date)
+        snapshot_ids = [s.id for s in snapshots]
+
+        queryset = CostEntry.objects.filter(snapshot_id__in=snapshot_ids)
+        if date:
+            queryset = queryset.filter(date=date)
+
+        filterset = self.filterset_class(request.GET, queryset=queryset)
+        queryset = filterset.qs
+
+        values_args = {}
+        for key, expr in self.group_by.items():
+            values_args[key] = expr
+
+        data = list(
+            queryset.values(**values_args)
+            .annotate(total_usd=Sum('cost_in_usd'))
+            .order_by()
+        )
+
+        response_data = {
+            'date': date.isoformat() if date else None,
+            'sources_queried': BillingBlobSource.objects.filter(is_active=True).count(),
+            'sources_included': len(snapshots),
+            'sources_missing': missing,
+            'data': data,
+        }
+
+        cache.set(cache_key, response_data, timeout=900)
+        return Response(response_data)
+
+
+class SubscriptionSummaryView(BaseSummaryView):
+    group_by = {
+        'subscription_id': F('subscription__subscription_id'),
+        'subscription_name': F('subscription__name'),
+    }
+
+
+class VirtualMachineSummaryView(SubscriptionSummaryView):
+    def get(self, request):
+        # Inject meter category filter
+        request.GET._mutable = True
+        if 'meter_category' not in request.GET:
+            request.GET['meter_category'] = 'Virtual Machines'
+        request.GET._mutable = False
+        return super().get(request)
+
+
+class ResourceGroupSummaryView(BaseSummaryView):
+    group_by = {
+        'resource_group': F('resource__resource_group'),
+    }
+
+
+class MeterCategorySummaryView(BaseSummaryView):
+    group_by = {
+        'meter_category': F('meter__category'),
+    }
+
+
+class RegionSummaryView(BaseSummaryView):
+    group_by = {
+        'location': F('resource__location'),
+    }

--- a/caching/__init__.py
+++ b/caching/__init__.py
@@ -1,0 +1,3 @@
+from .backends import get_cache_backend
+
+__all__ = ["get_cache_backend"]

--- a/caching/backends.py
+++ b/caching/backends.py
@@ -1,0 +1,35 @@
+class BaseCostCache:
+    """Interface for cache backends used by cost summary views."""
+    def get(self, key):
+        raise NotImplementedError
+
+    def set(self, key, value, timeout=None):
+        raise NotImplementedError
+
+
+class MemoryCostCache(BaseCostCache):
+    """In-memory cache using Django's default cache."""
+    def __init__(self, cache=None):
+        from django.core.cache import cache as default_cache
+        self._cache = cache or default_cache
+
+    def get(self, key):
+        return self._cache.get(key)
+
+    def set(self, key, value, timeout=None):
+        self._cache.set(key, value, timeout=timeout)
+
+
+class RedisCostCache(MemoryCostCache):
+    """Redis cache backend. Uses the configured default cache instance."""
+    pass
+
+
+def get_cache_backend():
+    """Return cache backend instance based on settings.COST_CACHE_IMPLEMENTATION."""
+    from django.conf import settings
+
+    impl = getattr(settings, "COST_CACHE_IMPLEMENTATION", "memory")
+    if impl == "redis":
+        return RedisCostCache()
+    return MemoryCostCache()

--- a/cielo_azure_billing/settings.py
+++ b/cielo_azure_billing/settings.py
@@ -130,3 +130,22 @@ LOGGING = {
         },
     },
 }
+
+if DEBUG:
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        }
+    }
+    COST_CACHE_IMPLEMENTATION = 'memory'
+else:
+    CACHES = {
+        'default': {
+            'BACKEND': 'django_redis.cache.RedisCache',
+            'LOCATION': 'redis://127.0.0.1:6379/1',
+            'OPTIONS': {
+                'CLIENT_CLASS': 'django_redis.client.DefaultClient',
+            }
+        }
+    }
+    COST_CACHE_IMPLEMENTATION = 'redis'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ drf-spectacular = "^0.28.0"
 django-filter = "^24.2"
 azure-identity = "^1.16.0"
 azure-storage-blob = "^12.19.0"
+django-redis = "^5.4"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Summary
- add configurable cache backend
- introduce cost summary APIs with shared filtering
- wire up new URLs
- add example subscription summary test

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced multiple new API endpoints for cost summaries, allowing aggregation by subscription, virtual machine, resource group, meter category, and region.
  - Added advanced filtering options for cost summary data, including support for filtering by tags and cost ranges.
  - Implemented caching for summary API responses to improve performance.

- **Bug Fixes**
  - No bug fixes included in this release.

- **Tests**
  - Added tests to ensure correct behavior of the subscription summary API endpoint.

- **Chores**
  - Updated environment-dependent cache configuration, supporting both in-memory and Redis caching.
  - Added a new dependency for Redis caching support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->