### PR TITLE
Add cost filtering docs and unify parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,19 +39,25 @@ snapshot that includes that date.
 
 ## API Filtering
 
-Cost entry endpoints accept the following query parameters:
+Cost entry and cost summary endpoints share a common set of query parameters.  
+These filters make it easy to drill down into specific subscriptions, resources
+or tagged costs.  The main options are:
 
-- `resourceGroupName`
-- `subscriptionName`
-- `meterCategory`
-- `meterSubCategory`
-- `serviceFamily`
-- `resourceLocation`
-- `chargeType`
-- `pricingModel`
-- `publisherName`
-- `costCenter`
-- `tags`
+- `date` – billing date (defaults to the latest available when omitted)
+- `subscription_id` – filter by subscription
+- `resource_group` – filter by resource group
+- `location` – filter by Azure region
+- `meter_category` – e.g. `Virtual Machines`, `Storage`
+- `meter_subcategory` – optional deeper filter such as `Premium SSD`
+- `pricing_model` – pricing model, e.g. `OnDemand`, `Spot`
+- `publisher_name` – filter Azure Marketplace charges
+- `resource_name` – filter by resource name
+- `min_cost` / `max_cost` – filter by cost range
+- `source_id` – filter results from a specific `BillingBlobSource`
+- `tag_key` and `tag_value` – filter by resource tags
+
+Legacy camelCase parameters like `resourceGroupName` are still accepted for
+backwards compatibility on the cost entry endpoint.
 
 ## Documentation
 
@@ -60,3 +66,5 @@ adding new management commands can be found in
 [`docs/DJANGO_COMMANDS.md`](docs/DJANGO_COMMANDS.md).
 Information on the automated blob import system lives in
 [`docs/BLOB_IMPORT.md`](docs/BLOB_IMPORT.md).
+Filtering examples for the API are provided in
+[`docs/CostsFilteringGuide.md`](docs/CostsFilteringGuide.md).

--- a/billing/filters.py
+++ b/billing/filters.py
@@ -15,6 +15,21 @@ class CostEntryFilter(filters.FilterSet):
     costCenter = filters.CharFilter(field_name='cost_center', lookup_expr='iexact')
     tags = filters.CharFilter(method='filter_tags')
 
+    # New parameter names matching summary endpoints
+    subscription_id = filters.CharFilter(field_name='subscription__subscription_id', lookup_expr='iexact')
+    resource_group = filters.CharFilter(field_name='resource__resource_group', lookup_expr='iexact')
+    location = filters.CharFilter(field_name='resource__location', lookup_expr='iexact')
+    meter_category = filters.CharFilter(field_name='meter__category', lookup_expr='iexact')
+    meter_subcategory = filters.CharFilter(field_name='meter__subcategory', lookup_expr='iexact')
+    pricing_model = filters.CharFilter(field_name='pricing_model', lookup_expr='iexact')
+    publisher_name = filters.CharFilter(field_name='publisher_name', lookup_expr='iexact')
+    resource_name = filters.CharFilter(field_name='resource__resource_name', lookup_expr='iexact')
+    min_cost = filters.NumberFilter(field_name='cost_in_usd', lookup_expr='gte')
+    max_cost = filters.NumberFilter(field_name='cost_in_usd', lookup_expr='lte')
+    source_id = filters.NumberFilter(field_name='snapshot__source_id')
+    tag_key = filters.CharFilter(method='filter_tag_key')
+    tag_value = filters.CharFilter(method='filter_tag_value')
+
     class Meta:
         model = CostEntry
         fields = []
@@ -22,6 +37,17 @@ class CostEntryFilter(filters.FilterSet):
     def filter_tags(self, queryset, name, value):
         if value:
             return queryset.filter(tags__contains=value)
+        return queryset
+
+    def filter_tag_key(self, queryset, name, value):
+        if value:
+            return queryset.filter(tags__has_key=value)
+        return queryset
+
+    def filter_tag_value(self, queryset, name, value):
+        key = self.data.get('tag_key')
+        if key and value:
+            return queryset.filter(tags__contains={key: value})
         return queryset
 
 

--- a/billing/tests/test_summary_api.py
+++ b/billing/tests/test_summary_api.py
@@ -35,4 +35,12 @@ class SubscriptionSummaryAPITests(TestCase):
         sub_ids = {item['subscription_id'] for item in data}
         self.assertEqual(sub_ids, {'sub1', 'sub2'})
 
+    def test_filter_by_subscription(self):
+        url = '/api/costs/subscription-summary/?date=2024-01-01&subscription_id=sub1'
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()['data']
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['subscription_id'], 'sub1')
+
 

--- a/docs/CostsFilteringGuide.md
+++ b/docs/CostsFilteringGuide.md
@@ -1,0 +1,26 @@
+# Filtering Cost API Endpoints
+
+All cost related API endpoints accept the same set of query parameters. These parameters allow you to limit results to a particular subscription, resource or tag and can be combined freely.
+
+| Parameter | Description |
+|-----------|-------------|
+| `date` | Billing date. When omitted, the API uses the latest available data. |
+| `subscription_id` | Filter by subscription ID. |
+| `resource_group` | Filter by Azure resource group. |
+| `location` | Azure region of the resource. |
+| `meter_category` | High level service category such as `Virtual Machines` or `Storage`. |
+| `meter_subcategory` | Optional sub category like `Premium SSD`. |
+| `pricing_model` | Pricing model, e.g. `OnDemand` or `Spot`. |
+| `publisher_name` | Marketplace publisher name. |
+| `resource_name` | Name of the resource. |
+| `min_cost`/`max_cost` | Cost range filters (in USD). |
+| `source_id` | ID of the `BillingBlobSource` import. |
+| `tag_key` and `tag_value` | Filter by resource tags. Use both together to match a specific tag pair. |
+
+Example request filtering by subscription and meter category:
+
+```http
+GET /api/costs/subscription-summary/?date=2024-01-01&subscription_id=abcd-1234&meter_category=Virtual%20Machines
+```
+
+Cost entry endpoints continue to honour their original camelCase parameters so existing clients will keep working.


### PR DESCRIPTION
## Summary
- expand cost entry filters to support summary parameter names
- document common filter parameters in README
- add CostsFilteringGuide for API users
- test new subscription_id filter

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*