### PR TITLE
Add available snapshot dates endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ To discover which billing dates are present, call
 `/api/costs/available-report-dates/?month=YYYY-MM` (defaults to the current
 month).
 
+To list the snapshot report dates that can be queried for summaries, use
+`/api/snapshots/available-report-dates/`.
+
 ## API Filtering
 
 Cost entry and cost summary endpoints share a common set of query parameters.  

--- a/billing/tests/test_snapshot_report_dates.py
+++ b/billing/tests/test_snapshot_report_dates.py
@@ -1,0 +1,50 @@
+import datetime
+from django.test import TestCase
+from billing.models import CostReportSnapshot
+
+
+class SnapshotReportDatesAPITests(TestCase):
+    def setUp(self):
+        CostReportSnapshot.objects.create(
+            run_id='r1',
+            report_date=datetime.date(2025, 5, 1),
+            file_name='f1',
+            status=CostReportSnapshot.Status.COMPLETE,
+        )
+        CostReportSnapshot.objects.create(
+            run_id='r2',
+            report_date=datetime.date(2025, 5, 10),
+            file_name='f2',
+            status=CostReportSnapshot.Status.COMPLETE,
+        )
+        # duplicate date should be collapsed
+        CostReportSnapshot.objects.create(
+            run_id='r3',
+            report_date=datetime.date(2025, 5, 10),
+            file_name='f3',
+            status=CostReportSnapshot.Status.COMPLETE,
+        )
+        # incomplete snapshot ignored
+        CostReportSnapshot.objects.create(
+            run_id='r4',
+            report_date=datetime.date(2025, 5, 15),
+            file_name='f4',
+            status=CostReportSnapshot.Status.IN_PROGRESS,
+        )
+        # null report_date ignored
+        CostReportSnapshot.objects.create(
+            run_id='r5',
+            report_date=None,
+            file_name='f5',
+            status=CostReportSnapshot.Status.COMPLETE,
+        )
+
+    def test_available_snapshot_report_dates(self):
+        resp = self.client.get('/api/snapshots/available-report-dates/')
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(
+            data['available_report_dates'],
+            ['2025-05-01', '2025-05-10'],
+        )
+

--- a/billing/urls.py
+++ b/billing/urls.py
@@ -13,6 +13,7 @@ from .views import (
     MeterCategorySummaryView,
     RegionSummaryView,
     AvailableReportDatesView,
+    SnapshotReportDatesView,
 )
 
 router = DefaultRouter()
@@ -31,4 +32,5 @@ urlpatterns = [
     path('costs/meter-category-summary/', MeterCategorySummaryView.as_view()),
     path('costs/region-summary/', RegionSummaryView.as_view()),
     path('costs/available-report-dates/', AvailableReportDatesView.as_view()),
+    path('snapshots/available-report-dates/', SnapshotReportDatesView.as_view()),
 ]

--- a/billing/views.py
+++ b/billing/views.py
@@ -293,3 +293,18 @@ class AvailableReportDatesView(APIView):
                 'available_dates': [d.isoformat() for d in dates],
             }
         )
+
+class SnapshotReportDatesView(APIView):
+    """Return distinct report_date values from completed snapshots."""
+    permission_classes = [PublicEndpointPermission]
+
+    def get(self, request):
+        dates = (
+            CostReportSnapshot.objects.filter(status=CostReportSnapshot.Status.COMPLETE)
+            .exclude(report_date__isnull=True)
+            .values_list('report_date', flat=True)
+            .distinct()
+            .order_by('report_date')
+        )
+        return Response({'available_report_dates': [d.isoformat() for d in dates]})
+


### PR DESCRIPTION
## Summary
- add `/api/snapshots/available-report-dates/` endpoint to list snapshot `report_date`s
- expose new view via urls
- document usage in README
- add regression test for endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*