### PR TITLE
Implement resource group normalization

### DIFF
--- a/billing/tests/test_importer.py
+++ b/billing/tests/test_importer.py
@@ -214,3 +214,30 @@ class CostCsvImporterTests(TestCase):
             resource = Resource.objects.get(resource_id='/some/path/res1')
             self.assertEqual(resource.resource_name, 'res1')
 
+    def test_resource_group_normalized(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            csv_path = f"{tmp}/cost.csv"
+            self._write_csv(csv_path, [{
+                'customerTenantId': 't1',
+                'SubscriptionId': 'sub1',
+                'subscriptionName': 'Sub One',
+                'ResourceId': '/r1',
+                'productOrderName': 'prod',
+                'resourceGroupName': ' MyRG ',
+                'resourceLocation': 'loc',
+                'meterId': 'm1',
+                'meterName': 'Meter',
+                'meterCategory': 'cat',
+                'meterSubCategory': 'sub',
+                'serviceFamily': 'fam',
+                'unitOfMeasure': 'u',
+                'date': '01/01/2024',
+                'costInUsd': '1'
+            }])
+            importer = CostCsvImporter(csv_path, run_id='run1', report_date=datetime.date(2024,1,1))
+            importer.import_file()
+
+            res = Resource.objects.get(resource_id='/r1')
+            self.assertEqual(res.resource_group, 'myrg')
+

--- a/docs/CostsFilteringGuide.md
+++ b/docs/CostsFilteringGuide.md
@@ -6,7 +6,7 @@ All cost related API endpoints accept the same set of query parameters. These pa
 |-----------|-------------|
 | `date` | Billing date. When omitted, the API uses the latest available data. |
 | `subscription_id` | Filter by subscription ID. |
-| `resource_group` | Filter by Azure resource group. |
+| `resource_group` | Filter by Azure resource group. Names are stored in lowercase. |
 | `location` | Azure region of the resource. |
 | `meter_category` | High level service category such as `Virtual Machines` or `Storage`. |
 | `meter_subcategory` | Optional sub category like `Premium SSD`. |


### PR DESCRIPTION
## Summary
- normalize resource group names to lowercase during CSV import
- ensure importer updates existing resources with normalized names
- document lowercase resource_group behavior
- test that resource groups are normalized on import

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6839ff774b608330b3be7d48b0a243db

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resource group names are now automatically normalized (lowercased and trimmed of whitespace) during import, ensuring consistent storage and filtering.

- **Tests**
  - Added a test to verify that resource group names are correctly normalized during CSV import.

- **Documentation**
  - Updated documentation to clarify that Azure resource group names are stored in lowercase for filtering purposes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->