### PR TITLE
Add JS redirect for root page

### DIFF
--- a/billing/templates/index.html
+++ b/billing/templates/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Cielo Azure Billing</title>
+    <script>
+        window.location.href = '/api/docs';
+    </script>
+</head>
+<body>
+    <p>If you are not redirected automatically, <a href="/api/docs">visit the documentation</a>.</p>
+</body>
+</html>

--- a/cielo_azure_billing/urls.py
+++ b/cielo_azure_billing/urls.py
@@ -1,8 +1,10 @@
 from django.contrib import admin
 from django.urls import path, include
+from django.views.generic import TemplateView
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 urlpatterns = [
+    path('', TemplateView.as_view(template_name='index.html'), name='index'),
     path('admin/', admin.site.urls),
     path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
     path('api/docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='docs'),


### PR DESCRIPTION
## Summary
- add a simple index.html template that redirects to `/api/docs`
- wire new template in `urls.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_683a9247ffe483308a4865bfcfb6b626