### PR TITLE
Fix Django project module references

### DIFF
--- a/example_django_project/asgi.py
+++ b/example_django_project/asgi.py
@@ -1,5 +1,5 @@
 import os
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'cielo_azure_billing.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'example_django_project.settings')
 application = get_asgi_application()

--- a/example_django_project/settings.py
+++ b/example_django_project/settings.py
@@ -30,7 +30,7 @@ MIDDLEWARE = [
     'cielo.azure.cost_analysis.middleware.RequestLoggingMiddleware',
 ]
 
-ROOT_URLCONF = 'cielo_azure_billing.urls'
+ROOT_URLCONF = 'example_django_project.urls'
 
 TEMPLATES = [
     {
@@ -48,7 +48,7 @@ TEMPLATES = [
     },
 ]
 
-WSGI_APPLICATION = 'cielo_azure_billing.wsgi.application'
+WSGI_APPLICATION = 'example_django_project.wsgi.application'
 
 DATABASES = {
     'default': {

--- a/example_django_project/wsgi.py
+++ b/example_django_project/wsgi.py
@@ -1,5 +1,5 @@
 import os
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'cielo_azure_billing.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'example_django_project.settings')
 application = get_wsgi_application()


### PR DESCRIPTION
## Summary
- use the correct project module name in settings, wsgi and asgi

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_683b0bb68b508330b5809cb2b51e2100