### PR TITLE
Fix Django app config name

### DIFF
--- a/src/cielo/azure/cost_analysis/apps.py
+++ b/src/cielo/azure/cost_analysis/apps.py
@@ -1,9 +1,11 @@
 from django.apps import AppConfig
 
 
-class BillingConfig(AppConfig):
+class CostAnalysisConfig(AppConfig):
+    """Application configuration for the cost analysis app."""
+
     default_auto_field = 'django.db.models.BigAutoField'
-    name = 'billing'
+    name = 'cielo.azure.cost_analysis'
 
     def ready(self):
         from . import signals  # Import signals to register them


### PR DESCRIPTION
## Summary
- fix app config name for `cielo.azure.cost_analysis`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_683b0d1c52388330a7ddc222045a4399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal naming to reflect the app's new focus on cost analysis. No impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->